### PR TITLE
scx_rustland: use new ring_buffer__consume_n API

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Framework to implement sched_ext schedulers running in user space
 [dependencies]
 anyhow = "1.0"
 plain = "0.2.3"
-libbpf-rs = "0.23.1"
+libbpf-rs = { git = "https://github.com/jfernandez/libbpf-rs.git", branch = "ringbuf-consume-n", version = "0.23.2" }
 libc = "0.2.137"
 buddy-alloc = "0.5.1"
 scx_utils = { path = "../scx_utils", version = "0.8" }

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -16,8 +16,8 @@ bindgen = ">=0.68, <0.70"
 glob = "0.3"
 hex = "0.4.3"
 lazy_static = "1.4"
-libbpf-cargo = "0.23"
-libbpf-rs = "0.23"
+libbpf-cargo = { git = "https://github.com/jfernandez/libbpf-rs.git", branch = "ringbuf-consume-n", version = "0.23.2" }
+libbpf-rs = { git = "https://github.com/jfernandez/libbpf-rs.git", branch = "ringbuf-consume-n", version = "0.23.2" }
 buddy-alloc = "0.5"
 log = "0.4"
 paste = "1.0"

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -12,7 +12,7 @@ plain = "0.2.3"
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7.0"
-libbpf-rs = "0.23.1"
+libbpf-rs = { git = "https://github.com/jfernandez/libbpf-rs.git", branch = "ringbuf-consume-n", version = "0.23.2" }
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"


### PR DESCRIPTION
This is a draft PR to get feedback on the scx part of this change. Once libbpf-sys 1.5.0 is released, we can use the upstream crate.

I updated my forks of `libbpf-sys` and `libbpf-rs` to support `ring_buffer__consume_n`, and pointed scx_rustland to those forks.